### PR TITLE
feat : 동적 라우트 세그먼트값 옵션 추가

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,13 +13,13 @@ function findAppDirectory(startDir) {
   if (fs.existsSync(srcAppPath) && fs.statSync(srcAppPath).isDirectory()) {
     return srcAppPath;
   }
-  
+
   // Look for 'app' in the current directory
   const appPath = path.join(startDir, 'app');
   if (fs.existsSync(appPath) && fs.statSync(appPath).isDirectory()) {
     return appPath;
   }
-  
+
   return null;
 }
 
@@ -32,13 +32,14 @@ function parseOptions(args) {
   const options = {
     treeMode: false,
     host: 'http://localhost:3000',
-    appDir: null
+    appDir: null,
+    slugs: {}, // slug 값을 저장할 객체 추가
   };
-  
+
   // Parse arguments
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
-    
+
     if (arg === '-t' || arg === '--tree') {
       options.treeMode = true;
     } else if (arg === '-h' || arg === '--host') {
@@ -51,9 +52,18 @@ function parseOptions(args) {
         options.appDir = args[i + 1];
         i++;
       }
+    } else if (arg === '-s' || arg === '--slug') {
+      if (i + 1 < args.length) {
+        const slugArg = args[i + 1];
+        const [key, value] = slugArg.split('=');
+        if (key && value) {
+          options.slugs[key] = value;
+        }
+        i++;
+      }
     }
   }
-  
+
   return options;
 }
 
@@ -68,12 +78,14 @@ function showHelp() {
     -t, --tree            Display route structure in tree format
     -h, --host <url>      Set base host URL (default: http://localhost:3000)
     -d, --dir <path>      Directly specify Next.js app directory
+    -s, --slug <key=value> Replace dynamic route segments (e.g., slug=github)
     --help                Display this help message
   
   Examples:
     npx show-nextjs-routers
     npx show-nextjs-routers -t
     npx show-nextjs-routers -h https://example.com
+    npx show-nextjs-routers -s brand=github -s category=coding
   `);
 }
 
@@ -87,25 +99,27 @@ function main(args) {
     showHelp();
     process.exit(0);
   }
-  
+
   // Parse options
   const options = parseOptions(args);
-  
+
   // Find app directory
   const appDir = options.appDir || findAppDirectory(process.cwd());
-  
+
   if (!appDir) {
     console.error('Next.js app directory not found.');
-    console.error('Please run from the root of a Next.js project or use -d option to specify app directory.');
+    console.error(
+      'Please run from the root of a Next.js project or use -d option to specify app directory.'
+    );
     process.exit(1);
   }
-  
+
   // Analyze and display routes
-  analyzeRoutes(appDir, options.host, options.treeMode);
+  analyzeRoutes(appDir, options.host, options.treeMode, options.slugs); // options.slugs 전달
 }
 
 module.exports = {
   main,
   findAppDirectory,
-  parseOptions
+  parseOptions,
 };

--- a/lib/router-analyzer.js
+++ b/lib/router-analyzer.js
@@ -7,12 +7,21 @@ const path = require('path');
 const DEFAULT_HOST = 'http://localhost:3000';
 
 /**
- * Convert [slug] format path to :slug format
- * @param {string} name - Path name
- * @return {string} Converted path name
+ * Convert [slug] format path to :slug format.
+ * If a specific value for the slug is provided in the slugs object, use that value.
+ * @param {string} name - Path name (e.g., "[brand]")
+ * @param {object} [slugs={}] - An object mapping slug keys to their values (e.g., { brand: "mybrand" })
+ * @return {string} Converted path name (e.g., "mybrand" or ":brand")
  */
-function asName(name) {
-  return name.replace(/\[([^\]]+)\]/g, ':$1');
+function asName(name, slugs = {}) {
+  if (name.startsWith('[') && name.endsWith(']')) {
+    const slugKey = name.substring(1, name.length - 1);
+    if (slugs && slugs[slugKey]) {
+      return slugs[slugKey];
+    }
+    return `:${slugKey}`;
+  }
+  return name;
 }
 
 /**
@@ -28,11 +37,12 @@ function isRouteGroup(segment) {
  * Generate Next.js route tree structure from a given directory
  * @param {string} dir - Starting directory (app directory)
  * @param {string} host - Host URL
+ * @param {object} [slugs={}] - An object mapping slug keys to their values
  * @param {string} relativePath - Relative path (used in recursive calls)
  * @param {Array} routeSegments - URL path segments (excluding route groups)
  * @return {object|null} Route tree structure or null (if no routes)
  */
-function buildTree(dir, host = DEFAULT_HOST, relativePath = '', routeSegments = []) {
+function buildTree(dir, host = DEFAULT_HOST, slugs = {}, relativePath = '', routeSegments = []) {
   // Return null if the directory doesn't exist
   if (!fs.existsSync(dir)) {
     return null;
@@ -41,7 +51,8 @@ function buildTree(dir, host = DEFAULT_HOST, relativePath = '', routeSegments = 
   try {
     const files = fs.readdirSync(dir);
     const segments = relativePath ? relativePath.split(path.sep) : [];
-    const nodeName = segments.length === 0 ? '/' : asName(segments[segments.length - 1]);
+    // The nodeName for the current level should also reflect slug substitution
+    const nodeName = segments.length === 0 ? '/' : asName(segments[segments.length - 1], slugs);
     
     // Find page file (Next.js route definition file)
     const pageFile = files.find(f => /^page\.(js|jsx|ts|tsx)$/.test(f));
@@ -49,7 +60,9 @@ function buildTree(dir, host = DEFAULT_HOST, relativePath = '', routeSegments = 
 
     // Generate route path if page file exists (excluding route groups)
     if (pageFile) {
-      let route = routeSegments.map(asName).join('/');
+      // Replace dynamic segments with slug values or :slug format
+      const processedRouteSegments = routeSegments.map(segment => asName(segment, slugs));
+      let route = processedRouteSegments.join('/');
       routePath = host + (route ? '/' + route : '');
     }
 
@@ -72,20 +85,25 @@ function buildTree(dir, host = DEFAULT_HOST, relativePath = '', routeSegments = 
         // Route segments only include non-route group folders
         const nextRouteSegments = [...routeSegments];
         if (!isGroup) {
-          nextRouteSegments.push(file);
+          // For route segments, we keep the original [slug] format
+          // asName will handle the conversion to :slug or actual value later
+          nextRouteSegments.push(file); 
         }
         
         const childTree = buildTree(
           fullPath, 
           host, 
+          slugs, // Pass slugs to recursive calls
           nextRelativePath,
           nextRouteSegments
         );
         
         if (childTree) {
+          // Node name should reflect the slug value if provided, or :slug
+          // childTree.name is already processed by the recursive call's asName
           children.push({
             ...childTree,
-            name: '📁 ' + childTree.name
+            name: '📁 ' + childTree.name // childTree.name is already slug-aware
           });
         }
       }
@@ -107,10 +125,12 @@ function buildTree(dir, host = DEFAULT_HOST, relativePath = '', routeSegments = 
 /**
  * Print tree structure as text
  * @param {object} node - Tree node
+ * @param {object} [slugs={}] - An object mapping slug keys to their values (currently not directly used by printTree)
  * @param {string} prefix - Line prefix (used in recursive calls)
  * @param {boolean} isRoot - Whether this is the root node
  */
-function printTree(node, prefix = '', isRoot = true) {
+function printTree(node, slugs = {}, prefix = '', isRoot = true) {
+  // Node name is already processed by buildTree, routePath also
   const urlStr = node.routePath ? ` [${node.routePath}]` : '';
   
   if (isRoot) {
@@ -120,6 +140,7 @@ function printTree(node, prefix = '', isRoot = true) {
   node.children.forEach((child, i) => {
     const isLast = i === node.children.length - 1;
     const branch = isLast ? '└─ ' : '├─ ';
+    // Child node name and routePath are already processed
     const childUrlStr = child.routePath ? ` [${child.routePath}]` : '';
     
     console.log(prefix + branch + child.name + childUrlStr);
@@ -127,7 +148,7 @@ function printTree(node, prefix = '', isRoot = true) {
     // Recursively print children if they exist
     if (child.children && child.children.length > 0) {
       const nextPrefix = prefix + (isLast ? '   ' : '│  ');
-      printTree(child, nextPrefix, false);
+      printTree(child, slugs, nextPrefix, false); // Pass slugs
     }
   });
 }
@@ -135,16 +156,17 @@ function printTree(node, prefix = '', isRoot = true) {
 /**
  * Print only URL list
  * @param {object} node - Tree node
+ * @param {object} [slugs={}] - An object mapping slug keys to their values (currently not directly used by printUrls)
  */
-function printUrls(node) {
-  // Print current node's URL if it exists
+function printUrls(node, slugs = {}) {
+  // routePath is already processed by buildTree with slug values
   if (node.routePath) {
     console.log(node.routePath);
   }
   
   // Recursively print URLs for all children
   if (node.children && node.children.length > 0) {
-    node.children.forEach(child => printUrls(child));
+    node.children.forEach(child => printUrls(child, slugs)); // Pass slugs
   }
 }
 
@@ -153,16 +175,17 @@ function printUrls(node) {
  * @param {string} appDir - Next.js app directory path
  * @param {string} host - Host URL
  * @param {boolean} treeMode - Whether to output in tree mode
+ * @param {object} [slugs={}] - An object mapping slug keys to their values
  * @return {object|null} Analyzed route tree structure
  */
-function analyzeRoutes(appDir, host = DEFAULT_HOST, treeMode = false) {
-  const tree = buildTree(appDir, host);
+function analyzeRoutes(appDir, host = DEFAULT_HOST, treeMode = false, slugs = {}) { // slugs 인자 추가
+  const tree = buildTree(appDir, host, slugs); // slugs 전달
   
   if (tree) {
     if (treeMode) {
-      printTree(tree);
+      printTree(tree, slugs); // slugs 전달
     } else {
-      printUrls(tree);
+      printUrls(tree, slugs); // slugs 전달
     }
     return tree;
   }


### PR DESCRIPTION
##  동적 라우트 세그먼트 커스터마이징 기능 추가

### 설명 (Description)
 `-s` 또는 `--slug <key=value>` CLI 옵션을 추가하여 동적 라우트 세그먼트의 값을 사용자가 지정할 수 있도록 개선했습니다.


### 테스트 방법
  ```bash
  npx show-nextjs-routers -s id=test-product -s category=books
  ```

### 예상 결과: 
URL 경로에서 `[id]`가 `test-product`로, `[category]`가 `books`로 출력됩니다.
예시: `http://localhost/:id/:category/slug` 와 같은 경로가 `http://localhost/test-product/books/slug` 형태로 출력됩니다.

